### PR TITLE
feat: add devcontainer to support multi-platform development

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,11 @@
+FROM ubuntu:22.04
+
+USER root
+
+# Install needed packages. Use a separate RUN statement to add your own dependencies.
+RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
+    && apt-get -y install build-essential cmake cppcheck valgrind clang lldb llvm gdb \
+    # [Optional] Additional packages required for using vcpkg package manager in manifest mode.
+    # [Optional] Please uncommment if the below line in needed.
+    # && apt-get -y install autoconf automake libtool m4 autoconf-archive \
+    && apt-get autoremove -y && apt-get clean -y && rm -rf /var/lib/apt/lists/*

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,34 @@
+{
+	"name": "webserv",
+	"build": {
+		"dockerfile": "Dockerfile"
+	},
+
+	// Features to add to the dev container. More info: https://containers.dev/features.
+	"features": {
+		"ghcr.io/devcontainers/features/common-utils:2": {
+			"installZsh": true,
+			"configureZshAsDefaultShell": true,
+			"upgradePackages": true,
+			"username": "automatic",
+			"userUid": "automatic",
+			"userGid": "automatic"
+		},
+		 "ghcr.io/devcontainers/features/git:1": {
+            "version": "latest",
+            "ppa": "false"
+        }
+	}
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [],
+
+	// Use 'postCreateCommand' to run commands after the container is created.
+	// "postCreateCommand": "gcc -v",
+
+	// Configure tool-specific properties.
+	// "customizations": {},
+
+	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+	// "remoteUser": "root"
+}


### PR DESCRIPTION
Introduce a development container to facilitate multi-platform development, particularly for macOS users. This setup allows for the use of `epoll` in a containerized environment, ensuring compatibility and ease of development across different operating systems.

Fixes #16