### PR TITLE
fix(config): `max_request_body` missing in location blocks parsing

### DIFF
--- a/src/config/Config.cpp
+++ b/src/config/Config.cpp
@@ -710,6 +710,10 @@ void Config::translateLocationBlock_(const BlockNode& location_block,
       requireArgsEqual_(d, 1);
       loc.cgi = parseBooleanValue_(d.args[0]);
       LOG(DEBUG) << "  Location CGI: " << (loc.cgi ? "on" : "off");
+    } else if (d.name == "max_request_body") {
+      requireArgsEqual_(d, 1);
+      loc.max_request_body = parsePositiveNumber_(d.args[0]);
+      LOG(DEBUG) << "  Location max_request_body: " << loc.max_request_body;
     } else {
       throwUnrecognizedDirective_(d, "in location block");
     }

--- a/src/config/Location.cpp
+++ b/src/config/Location.cpp
@@ -12,7 +12,8 @@ Location::Location()
       index(),
       autoindex(false),
       root(),
-      error_page() {
+      error_page(),
+      max_request_body(0) {
   LOG(DEBUG) << "Location() default constructor called";
   initDefaultHttpMethods(allow_methods);
   LOG(DEBUG)
@@ -29,7 +30,8 @@ Location::Location(const std::string& p)
       index(),
       autoindex(false),
       root(),
-      error_page() {
+      error_page(),
+      max_request_body(0) {
   LOG(DEBUG) << "Location(path) constructor called with path: " << p;
   initDefaultHttpMethods(allow_methods);
   LOG(DEBUG) << "Location '" << path
@@ -45,7 +47,8 @@ Location::Location(const Location& other)
       index(other.index),
       autoindex(other.autoindex),
       root(other.root),
-      error_page(other.error_page) {}
+      error_page(other.error_page),
+      max_request_body(other.max_request_body) {}
 
 Location& Location::operator=(const Location& other) {
   if (this != &other) {
@@ -58,6 +61,7 @@ Location& Location::operator=(const Location& other) {
     autoindex = other.autoindex;
     root = other.root;
     error_page = other.error_page;
+    max_request_body = other.max_request_body;
   }
   return *this;
 }

--- a/src/config/Location.hpp
+++ b/src/config/Location.hpp
@@ -27,4 +27,5 @@ class Location {
   bool autoindex;
   std::string root;
   std::map<http::Status, std::string> error_page;
+  std::size_t max_request_body;
 };


### PR DESCRIPTION
Fixes #149