### PR TITLE
fix: a funzione validateScriptPath viene chiamata prima su script_pat…

### DIFF
--- a/src/core/Connection.cpp
+++ b/src/core/Connection.cpp
@@ -248,11 +248,27 @@ void Connection::processResponse(const Location& location) {
   }
 
   if (location.cgi) {
-    // CGI handling
+    // CGI handling - need to find the actual script in the path
+    // For URIs like /cgi-bin/test.py/extra/path, we need to find test.py
     std::string resolved_path;
     bool is_directory = false;
     if (!resolvePathForLocation(location, resolved_path, is_directory)) {
       return;  // resolvePathForLocation prepared an error response
+    }
+
+    // If the resolved path doesn't exist as a file, try to find the CGI script
+    // by progressively removing path segments from the end
+    struct stat st;
+    std::string script_path = resolved_path;
+    while (stat(script_path.c_str(), &st) != 0 || !S_ISREG(st.st_mode)) {
+      // Remove last path segment
+      size_t last_slash = script_path.find_last_of('/');
+      if (last_slash == std::string::npos || last_slash == 0) {
+        // No more segments to remove, script not found
+        prepareErrorResponse(http::S_404_NOT_FOUND);
+        return;
+      }
+      script_path = script_path.substr(0, last_slash);
     }
 
     if (is_directory) {
@@ -260,7 +276,7 @@ void Connection::processResponse(const Location& location) {
       return;
     }
 
-    IHandler* handler = new CgiHandler(resolved_path);
+    IHandler* handler = new CgiHandler(script_path);
     setHandler(handler);
 
     HandlerResult hr = active_handler->start(*this);

--- a/www/cgi-bin/path_info_test.py
+++ b/www/cgi-bin/path_info_test.py
@@ -1,0 +1,12 @@
+#!/usr/bin/python3
+
+import os
+
+print("Content-Type: text/plain")
+print()
+
+print("=== PATH_INFO Test ===")
+print(f"REQUEST_URI: {os.environ.get('REQUEST_URI', 'Not set')}")
+print(f"SCRIPT_NAME: {os.environ.get('SCRIPT_NAME', 'Not set')}")
+print(f"PATH_INFO: {os.environ.get('PATH_INFO', 'Not set')}")
+print(f"QUERY_STRING: {os.environ.get('QUERY_STRING', 'Not set')}")


### PR DESCRIPTION
…h_ (es. test.py), che è il path del file CGI risolto. Ma quando la URI contiene un PATH_INFO extra (es. /cgi-bin/test.py/extra/path), quel path extra non viene mai verificato perché script_path_ è già stato risolto al file CGI esistente