### PR TITLE
Config: Streamline directive parsing

### DIFF
--- a/src/config/Config.hpp
+++ b/src/config/Config.hpp
@@ -19,7 +19,7 @@ class Config {
   std::vector<Server> getServers(void);
   void debug(void) const;
 
- private:
+ public:
   std::vector<std::string> tokens_;
   BlockNode root_;
   std::vector<Server> servers_;
@@ -39,6 +39,13 @@ class Config {
   bool isBlock() const;
   BlockNode parseBlock();
   DirectiveNode parseDirective();
+
+  // Handler map for directive processing
+  typedef void (Config::*DirectiveHandler)(const DirectiveNode&);
+  static std::map<std::string, DirectiveHandler> directive_handlers_;
+  // Declaration of the static directive handlers map
+  void handleErrorPage(const DirectiveNode& d);
+  void handleMaxRequestBody(const DirectiveNode& d);
 
   // Argument parsers
   int parsePortValue_(const std::string& portstr);

--- a/src/config/Config_test.cpp
+++ b/src/config/Config_test.cpp
@@ -149,6 +149,39 @@ TEST(ConfigListen, MissingListenThrows) {
   EXPECT_THROW(cfg.getServers(), std::runtime_error);
 }
 
+TEST(ConfigListen, MissingListenErrorMessage) {
+  std::string config =
+      "server {\n"
+      "  root /var/www;\n"
+      "}\n";
+
+  TempConfigFile tmpFile(config);
+  Config cfg;
+  cfg.parseFile(tmpFile.path());
+
+  try {
+    cfg.getServers();
+    FAIL() << "Expected std::runtime_error";
+  } catch (const std::runtime_error& e) {
+    std::string msg = e.what();
+    EXPECT_NE(msg.find("missing 'listen' directive"), std::string::npos)
+        << "Error message should mention missing 'listen' directive: " << msg;
+  }
+}
+
+TEST(ConfigListen, MissingBothListenAndRoot) {
+  std::string config =
+      "server {\n"
+      "}\n";
+
+  TempConfigFile tmpFile(config);
+  Config cfg;
+  cfg.parseFile(tmpFile.path());
+
+  // Should throw for missing listen (checked first)
+  EXPECT_THROW(cfg.getServers(), std::runtime_error);
+}
+
 TEST(ConfigListen, PortOnly) {
   std::string config =
       "server {\n"
@@ -262,6 +295,26 @@ TEST(ConfigRoot, MissingRootThrows) {
   cfg.parseFile(tmpFile.path());
 
   EXPECT_THROW(cfg.getServers(), std::runtime_error);
+}
+
+TEST(ConfigRoot, MissingRootErrorMessage) {
+  std::string config =
+      "server {\n"
+      "  listen 8080;\n"
+      "}\n";
+
+  TempConfigFile tmpFile(config);
+  Config cfg;
+  cfg.parseFile(tmpFile.path());
+
+  try {
+    cfg.getServers();
+    FAIL() << "Expected std::runtime_error";
+  } catch (const std::runtime_error& e) {
+    std::string msg = e.what();
+    EXPECT_NE(msg.find("missing 'root' directive"), std::string::npos)
+        << "Error message should mention missing 'root' directive: " << msg;
+  }
 }
 
 TEST(ConfigRoot, ValidRootPath) {


### PR DESCRIPTION
Centralizzazione della gestione delle direttive
Ho sostituito la vecchia logica basata su una serie di if/else per il parsing delle direttive globali con una mappa statica ([std::map<std::string, DirectiveHandler>](vscode-file://vscode-app/c:/Users/iperf/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html)) che associa il nome della direttiva a una funzione handler dedicata.
Questo rende il codice più modulare, estendibile e leggibile: per aggiungere una nuova direttiva basta aggiungere una entry nella mappa e la relativa funzione.

Compatibilità C++98
L’inizializzazione della mappa statica è stata fatta tramite una struct ausiliaria e non con initializer list, per garantire compatibilità con C++98.

Handler dedicati
Le funzioni come [handleErrorPage](vscode-file://vscode-app/c:/Users/iperf/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) e [handleMaxRequestBody](vscode-file://vscode-app/c:/Users/iperf/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) sono ora funzioni membro che si occupano della validazione e dell’assegnazione dei valori delle rispettive direttive.

Pulizia e rimozione warning